### PR TITLE
O8 - Split play/pause, added fast forward, rewind, and eject buttons

### DIFF
--- a/src/components/CassettePlayer.jsx
+++ b/src/components/CassettePlayer.jsx
@@ -1,9 +1,15 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Pause, Play } from 'lucide-react';
+import { Pause, Play, FastForward, Rewind, ArrowDownFromLine } from 'lucide-react';
 
-const CassettePlayer = ({ position, color, srcAudio }) => {
+const SCRUB_MULTIPLIER = 4; // Adjust this to change speed
+const FAST_FORWARD = 1;
+const REWIND = -1;
+
+const CassettePlayer = ({ position, color, srcAudio, ejectCassette }) => {
     const [isPlaying, setIsPlaying] = useState(false);
     const audioRef = useRef(null);
+    const scrubIntervalRef = useRef(null);
+    const scrubStartTimeRef = useRef(null);
 
     useEffect(() => {
         setIsPlaying(false);
@@ -12,26 +18,57 @@ const CassettePlayer = ({ position, color, srcAudio }) => {
         }
     }, [srcAudio]);
 
-    const togglePlayPause = () => {
-        if (audioRef.current) {
-            if (srcAudio) {
-                if (isPlaying) {
-                    audioRef.current.pause();
-                } else {
-                    audioRef.current.play();
-                }
-                setIsPlaying(!isPlaying);
-            } else {
-                setIsPlaying(false);
-                audioRef.current.pause();
-            }
+    const pressPlay = () => {
+        if (audioRef.current && srcAudio) {
+            audioRef.current.play();
+            setIsPlaying(true);
         }
+    }
+
+    const pressPause = () => {
+        if (audioRef.current && srcAudio) {
+            audioRef.current.pause();
+            setIsPlaying(false);
+        }
+    }
+
+    const startScrub = (ff_or_rwd) => {
+        if (audioRef.current && srcAudio) {
+            // Store when we started holding the button
+            audioRef.current.pause();
+            scrubStartTimeRef.current = Date.now();
+            
+            // Set up interval to update time while holding
+            scrubIntervalRef.current = setInterval(() => {
+                const heldDuration = (Date.now() - scrubStartTimeRef.current) / 1000; // Convert to seconds
+                const skipAmount = heldDuration * SCRUB_MULTIPLIER * ff_or_rwd;
+                audioRef.current.currentTime = Math.min(
+                    audioRef.current.currentTime + skipAmount,
+                    audioRef.current.duration
+                );
+            }, 100); // Update every 100ms
+        }
+    };
+
+    const stopScrub = () => {
+        if (scrubIntervalRef.current) {
+            if (isPlaying && audioRef.current && srcAudio) {
+                audioRef.current.play();
+            }
+            clearInterval(scrubIntervalRef.current);
+            scrubIntervalRef.current = null;
+        }
+        scrubStartTimeRef.current = null;
+    };
+
+    const pressEject = () => {
+        ejectCassette();
     };
 
     return (
         <>
             <div
-                className="absolute w-48 h-48 rounded-lg transition-colors duration-300"
+                className="absolute w-52 h-48 rounded-lg transition-colors duration-300"
                 style={{
                     left: position.x - 25,
                     top: position.y - 25,
@@ -39,11 +76,39 @@ const CassettePlayer = ({ position, color, srcAudio }) => {
                     boxShadow: 'inset 0 0 10px rgba(0,0,0,0.5)'
                 }}
             >
-                <button 
-                    className="absolute bottom-0 left-1/2 -translate-x-1/2" 
-                    onClick={togglePlayPause}>
-                    {isPlaying ? <Pause size={24} /> : <Play size={24} />}
-                </button>
+                <div className="absolute w-52 h-12 bottom-0 left-1/2 -translate-x-1/2">
+                    <button className="w-4 h-12" 
+                        onClick={pressPlay}>
+                        <Play className="left-1/2 -translate-x-1/2" size={16} />
+                    </button>
+                    <button className="w-4 h-12" 
+                        onClick={pressPause}>
+                        <Pause className="left-1/2 -translate-x-1/2" size={16} />
+                    </button>
+                    <button className="w-4 h-12" 
+                        onMouseDown={() => startScrub(FAST_FORWARD)}
+                        onTouchStart={() => startScrub(FAST_FORWARD)}
+                        onMouseUp={stopScrub}
+                        onMouseLeave={stopScrub} // Stop if mouse leaves while holding
+                        onTouchEnd={stopScrub}
+                        >
+                        <FastForward className="left-1/2 -translate-x-1/2" size={16} />
+                    </button>
+                    <button className="w-4 h-12" 
+                        onMouseDown={() => startScrub(REWIND)}
+                        onTouchStart={() => startScrub(REWIND)}
+                        onMouseUp={stopScrub}
+                        onMouseLeave={stopScrub} // Stop if mouse leaves while holding
+                        onTouchEnd={stopScrub}
+                        >
+                        <Rewind className="left-1/2 -translate-x-1/2" size={16} />
+                    </button>
+                    <button className="w-4 h-12" 
+                        onClick={pressEject}>
+                        <ArrowDownFromLine className="left-1/2 -translate-x-1/2" size={16} />
+                    </button>
+
+                </div>
 
                 <audio ref={audioRef} src={srcAudio}/>
             </div>

--- a/src/components/CassetteTable.jsx
+++ b/src/components/CassetteTable.jsx
@@ -17,6 +17,21 @@ const CassetteTable = () => {
     const [draggedCassette, setDraggedCassette] = useState(null);
     const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
   
+    const ejectCassette = () => {
+      setCassettes(prevCassettes => prevCassettes.map(cassette => {
+        if (cassette.locked === true) {
+          return {
+            ...cassette,
+            position: { x: (cassette.id - 1) * 100 + 50, y: 50 },  // release position
+            locked: false
+          };
+        }
+        return cassette;
+      }));
+      setPlayerAudio(null);
+      setPlayerColor('#2C3E50');
+    }
+
     useEffect(() => {
       if (draggedCassette !== null) {
         
@@ -104,7 +119,7 @@ const CassetteTable = () => {
   
     return (
         <div className="relative w-full h-96 select-none">
-            <CassettePlayer position={player.position} color={playerColor} srcAudio={playerAudio} />
+            <CassettePlayer position={player.position} color={playerColor} srcAudio={playerAudio} ejectCassette={ejectCassette} />
             
             {cassettes.map(cassette => (
             <div


### PR DESCRIPTION
Split the play/pause button into Play and Pause buttons.
Added Fast Forward, Rewind, and Eject buttons.

`CassettePlayer.jsx`
- `pressPlay` and `pressPause` functions
- Fast Forward and Rewind are handled with `startScrub` and `stopScrub`, which calculate and apply a skip duration to audioRef based on how long the button was held. Constants passed in for FF or RWD.
- `pressEject` calls callback prop `ejectCassette` when Eject button is pressed

`CassetteTable.jsx`
- `ejectCassette` unlocks any locked cassette and updates the player color and audio src. Passed as a prop to the player.